### PR TITLE
NEW Track broken links and files within ElementContent

### DIFF
--- a/src/Extensions/ElementalAreasExtension.php
+++ b/src/Extensions/ElementalAreasExtension.php
@@ -229,12 +229,22 @@ class ElementalAreasExtension extends DataExtension
 
         $ownerClassName = get_class($this->owner);
 
-        // Update the OwnerClassName on EA if the class has changed
         foreach ($elementalAreaRelations as $eaRelation) {
+            // Update the OwnerClassName on EA if the class has changed
+            /** @var ElementalArea $ea */
             $ea = $this->owner->$eaRelation();
             if ($ea->OwnerClassName !== $ownerClassName) {
                 $ea->OwnerClassName = $ownerClassName;
                 $ea->write();
+            }
+
+            // Owner page will have set its own HasBrokenLink / HasBrokenFile in SiteTreeLinkTracking / FileLinkTracking
+            // on any $page->Content BEFORE we get to this point
+            if (count(array_filter($ea->Elements()->column('HasBrokenLink')))) {
+                $this->owner->HasBrokenLink = true;
+            }
+            if (count(array_filter($ea->Elements()->column('HasBrokenFile')))) {
+                $this->owner->HasBrokenFile = true;
             }
         }
 

--- a/src/Models/BaseElement.php
+++ b/src/Models/BaseElement.php
@@ -70,7 +70,9 @@ class BaseElement extends DataObject
         'ShowTitle' => 'Boolean',
         'Sort' => 'Int',
         'ExtraClass' => 'Varchar(255)',
-        'Style' => 'Varchar(255)'
+        'Style' => 'Varchar(255)',
+        'HasBrokenLink' => 'Boolean',
+        'HasBrokenFile' => 'Boolean',
     ];
 
     private static $has_one = [
@@ -291,6 +293,9 @@ class BaseElement extends DataObject
 
             // Remove link and file tracking tabs
             $fields->removeByName(['LinkTracking', 'FileTracking']);
+
+            // Remove SiteTreeLinkTracking and FileLinkTracking fields
+            $fields->removeByName(['HasBrokenLink', 'HasBrokenFile']);
 
             $fields->addFieldToTab(
                 'Root.Settings',

--- a/src/Models/ElementContent.php
+++ b/src/Models/ElementContent.php
@@ -12,7 +12,7 @@ class ElementContent extends BaseElement
     private static $icon = 'font-icon-block-content';
 
     private static $db = [
-        'HTML' => 'HTMLText'
+        'HTML' => 'HTMLText',
     ];
 
     private static $table_name = 'ElementContent';


### PR DESCRIPTION
Fix for https://github.com/dnadesign/silverstripe-elemental/issues/689

Also relates to https://github.com/silverstripeltd/product-issues/issues/224 (repository is not publically viewable)

The goal of this issue is to get the [BrokenLinksReport](https://github.com/silverstripe/silverstripe-cms/blob/4/code/Reports/BrokenLinksReport.php) to also read content from Elemental Blocks

SiteTreeLinkTracking and FileLinkTracking are on every DataObject by default, so there's not a whole lot we need to do to enable this functionality on ElementContent

https://github.com/silverstripe/silverstripe-cms/blob/4/_config/linktracking.yml

Updating the tracking only on SiteTree->write() and not ElementContent->write() to prevent unintended consequences, for instance, when I save the Element inline in the CMS I do not expect the Page to save too

