### PR TITLE
NEW: Better type default.

### DIFF
--- a/src/Models/BaseElement.php
+++ b/src/Models/BaseElement.php
@@ -394,7 +394,7 @@ JS
     {
         $default = $this->i18n_singular_name() ?: 'Block';
 
-        return _t(__CLASS__ . '.BlockType' , $default);
+        return _t(__CLASS__ . '.BlockType', $default);
     }
 
     /**

--- a/src/Models/BaseElement.php
+++ b/src/Models/BaseElement.php
@@ -392,7 +392,9 @@ JS
      */
     public function getType()
     {
-        return _t(__CLASS__ . '.BlockType', 'Block');
+        $default = $this->i18n_singular_name() ?: 'Block';
+
+        return _t(__CLASS__ . '.BlockType' , $default);
     }
 
     /**


### PR DESCRIPTION
# Better type default for BaseElement

* better default for the `Type` on `BaseElement`
* simplified configuration (configured by `singular_name`)
* localisation is retained

## Related issues

https://github.com/dnadesign/silverstripe-elemental/issues/831