### PR TITLE
BUG AddElementPopoverComponent button is submit.

### DIFF
--- a/client/src/components/ElementEditor/HoverBar.js
+++ b/client/src/components/ElementEditor/HoverBar.js
@@ -21,6 +21,7 @@ function StatelessHoverBar({
   const lineClasses = `${classNames('-line')} font-icon-plus-circled`;
   const label = i18n._t('ElementAddNewButton.ADD_BLOCK', 'Add block');
   const btnProps = {
+    type: 'button',
     className: classNames('-area', { '-area--focus': popoverOpen }),
     onClick: onToggle,
     'aria-label': label,


### PR DESCRIPTION
By omitting the button type, this is automatically a submit button. This means pressing the enter key while in an input field triggers this button instead of a true form submit button, and also sends unnecessary form submit events when the form isn't actually being submitted.