### PR TITLE
BUG ignored_classes Content field emptied by MigrateContentToElement task

### DIFF
--- a/src/Tasks/MigrateContentToElement.php
+++ b/src/Tasks/MigrateContentToElement.php
@@ -138,6 +138,9 @@ class MigrateContentToElement extends BuildTask
     protected function isMigratable($pageType)
     {
         $migratable = SiteTree::has_extension($pageType, ElementalPageExtension::class);
+        if (in_array($pageType, Config::inst()->get(ElementalPageExtension::class, 'ignored_classes'))) {
+            $migratable = false;
+        }
 
         $this->extend('updateIsMigratable', $migratable, $pageType);
 

--- a/src/Tasks/MigrateContentToElement.php
+++ b/src/Tasks/MigrateContentToElement.php
@@ -9,6 +9,7 @@ use DNADesign\Elemental\Models\ElementalArea;
 use DNADesign\Elemental\Models\ElementContent;
 use Exception;
 use SilverStripe\CMS\Model\SiteTree;
+use SilverStripe\Core\Config\Config;
 use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Dev\BuildTask;
 use SilverStripe\Versioned\Versioned;


### PR DESCRIPTION
Classes in the ignored_classes configuration array don't have an elemental area. This fixes a bug where those classes have their Content field cleared even though it cannot be migrated into an elemental block.