### PR TITLE
FIX Prevent users without create permissions from duplicating blocks

### DIFF
--- a/src/GraphQL/DuplicateElementMutation.php
+++ b/src/GraphQL/DuplicateElementMutation.php
@@ -56,6 +56,11 @@ class DuplicateElementMutation extends MutationCreator implements OperationResol
                 "The current user has insufficient permission to edit ElementalArea: $areaID"
             );
         }
+        if (!$element->canCreate($context['currentUser'])) {
+            throw new InvalidArgumentException(
+                "The current user has insufficient permission to create or duplicate BaseElement: $elementID"
+            );
+        }
 
         try {
             // clone element

--- a/tests/GraphQL/DuplicateElementMutationTest.php
+++ b/tests/GraphQL/DuplicateElementMutationTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace DNADesign\Elemental\Tests\GraphQL;
+
+use DNADesign\Elemental\GraphQL\DuplicateElementMutation;
+use DNADesign\Elemental\Models\BaseElement;
+use DNADesign\Elemental\Models\ElementalArea;
+use GraphQL\Type\Definition\ResolveInfo;
+use InvalidArgumentException;
+use SilverStripe\Dev\SapphireTest;
+use SilverStripe\Security\Security;
+
+class DuplicateElementMutationTest extends SapphireTest
+{
+    public function testResolvePermissions()
+    {
+        $cannotEditClass = new class extends BaseElement {
+            public function canEdit($member = null)
+            {
+                return false;
+            }
+            public function canCreate($member = null, $context = [])
+            {
+                return true;
+            }
+        };
+
+        $cannotCreateClass = new class extends BaseElement {
+            public function canEdit($member = null)
+            {
+                return true;
+            }
+            public function canCreate($member = null, $context = [])
+            {
+                return false;
+            }
+        };
+
+        $area = new ElementalArea();
+        $area->write();
+
+        $testCases = [
+            [$cannotEditClass, 'edit'],
+            [$cannotCreateClass, 'create'],
+        ];
+
+        foreach ($testCases as $data) {
+            [$class, $operation] = $data;
+
+            $element = new $class();
+            $element->ParentID = $area->ID;
+            $element->write();
+            $mutation = new DuplicateElementMutation();
+            $object = null;
+            $args = ['ID' => $element->ID];
+            $context = ['currentUser' => Security::getCurrentUser()];
+            $resolveInfo = new ResolveInfo([]);
+
+            $this->expectException(InvalidArgumentException::class);
+            $this->expectExceptionMessageRegExp("#insufficient permission to {$operation}#");
+            $mutation->resolve($object, $args, $context, $resolveInfo);
+        }
+    }
+}


### PR DESCRIPTION
Fix for https://github.com/dnadesign/silverstripe-elemental/issues/857

Related https://github.com/dnadesign/silverstripe-elemental/pull/874 (deals with UX)

Original PR https://github.com/dnadesign/silverstripe-elemental/pull/859

I've put down James Zhu as a co-author in the commit message

You can easily simulate not having create permissions by creating a regular content block, the add `return false;` to the top of `BaseElement::canCreate()`

Currently this fix will:
- prevents the user from duplicating the content block
- change the graphql response
- add some test coverage

![image](https://user-images.githubusercontent.com/4809037/108436222-e9114b00-72af-11eb-8e65-ff2b6051dfe1.png)

===============================================================================

**Below this line now being dealt with on https://github.com/dnadesign/silverstripe-elemental/pull/874:**

However the user experience is poor, there is no feedback to the end user that anything has happened

There are two ways I can think of that would resolve this:

a) Not show the duplicate option in the drop down if the user lacks create permissions~~

![image](https://user-images.githubusercontent.com/4809037/108436403-3db4c600-72b0-11eb-8414-8a23bca3400c.png)

~~b) Still show the duplicate option, though show a red toast when a user clicks this with the message "The current user has insufficient permission to edit ElementalArea: $areaID"

Let me know what you'd like @clarkepaul~~