### PR TITLE
Ability to specify location for Elemental field via custom "insert before" config

### DIFF
--- a/src/Extensions/ElementalAreasExtension.php
+++ b/src/Extensions/ElementalAreasExtension.php
@@ -202,7 +202,11 @@ class ElementalAreasExtension extends DataExtension
 
             $editor = ElementalAreaField::create($eaRelationship, $area, $this->getElementalTypes());
 
-            if ($this->owner instanceof SiteTree && $fields->findOrMakeTab('Root.Main')->fieldByName('Metadata')) {
+            $insertBefore = Config::inst()->get(get_class($this->owner), 'insert_before_field_name');
+            
+            if ($insertBefore && $fields->dataFieldByName($insertBefore)) {
+                $fields->addFieldToTab('Root.Main', $editor, $insertBefore);
+            } else if ($this->owner instanceof SiteTree && $fields->findOrMakeTab('Root.Main')->fieldByName('Metadata')) {
                 $fields->addFieldToTab('Root.Main', $editor, 'Metadata');
             } else {
                 $fields->addFieldToTab('Root.Main', $editor);


### PR DESCRIPTION
Currently, the Elemental field is just added to the bottom of the field list (or above 'Metadata'). This PR adds the ability to specify a custom "insert before" field name so that the elemental field can be positioned somewhere more suitable on a per class basis.

e.g. when adding Elemental to the Silverstripe blog module, it results in the Elemental field appearing below the Featured Image and Custom Summary fields, which isn't ideal. So this can now be resolved with a new `insert_before_field_name` config option:

````
SilverStripe\Blog\Model\BlogPost:
  extensions:
    - DNADesign\Elemental\Extensions\ElementalPageExtension
  insert_before_field_name: 'FeaturedImage'
````