### PR TITLE
FIX `getElementsForSearch()` to replace tags with spaces

### DIFF
--- a/src/Extensions/ElementalPageExtension.php
+++ b/src/Extensions/ElementalPageExtension.php
@@ -43,7 +43,8 @@ class ElementalPageExtension extends ElementalAreasExtension
                 /** @var ElementalArea $area */
                 $area = $this->owner->$key();
                 if ($area) {
-                    $output[] = strip_tags($area->forTemplate());
+                    // Replace HTML tags with spaces
+                    $output[] = strip_tags(str_replace('<', ' <', $area->forTemplate()));
                 }
             }
         } finally {

--- a/tests/ElementalPageExtensionTest.php
+++ b/tests/ElementalPageExtensionTest.php
@@ -97,4 +97,21 @@ class ElementalPageExtensionTest extends FunctionalTest
             'Duplicated page has duplicated area and duplicated elements, i.e. not shared'
         );
     }
+
+    public function testGetElementsForSearch()
+    {
+        /** @var TestPage $page */
+        $page = $this->objFromFixture(TestPage::class, 'page_with_html_elements');
+        $output = $page->getElementsForSearch();
+        $this->assertNotEmpty($output);
+
+        // Confirm tags have been stripped
+        $this->assertNotContains('<p>', $output);
+        $this->assertNotContains('</p>', $output);
+
+        // Confirm paragraphs don't get smushed together, also across elements
+        $this->assertNotContains('paragraphAnd', $output);
+        $this->assertNotContains('oneMore', $output);
+        $this->assertNotContains('paragraphsAnd', $output);
+    }
 }

--- a/tests/ElementalPageExtensionTest.php
+++ b/tests/ElementalPageExtensionTest.php
@@ -106,12 +106,12 @@ class ElementalPageExtensionTest extends FunctionalTest
         $this->assertNotEmpty($output);
 
         // Confirm tags have been stripped
-        $this->assertNotContains('<p>', $output);
-        $this->assertNotContains('</p>', $output);
+        $this->assertStringNotContainsString('<p>', $output);
+        $this->assertStringNotContainsString('</p>', $output);
 
         // Confirm paragraphs don't get smushed together, also across elements
-        $this->assertNotContains('paragraphAnd', $output);
-        $this->assertNotContains('oneMore', $output);
-        $this->assertNotContains('paragraphsAnd', $output);
+        $this->assertStringNotContainsString('paragraphAnd', $output);
+        $this->assertStringNotContainsString('oneMore', $output);
+        $this->assertStringNotContainsString('paragraphsAnd', $output);
     }
 }

--- a/tests/ElementalPageExtensionTest.yml
+++ b/tests/ElementalPageExtensionTest.yml
@@ -3,6 +3,8 @@ DNADesign\Elemental\Models\ElementalArea:
     Title: Area 51
   area52:
     Title: Area 52
+  area53:
+    Title: Area 53
 DNADesign\Elemental\Models\ElementContent:
   content1:
     Title: Test Content
@@ -16,6 +18,16 @@ DNADesign\Elemental\Models\ElementContent:
     Title: More third content
     Sort: 1
     ParentID: =>DNADesign\Elemental\Models\ElementalArea.area52
+  content4:
+    Title: Paragraph content
+    Sort: 1
+    HTML: '<p>One paragraph</p><p>And another one</p>'
+    ParentID: =>DNADesign\Elemental\Models\ElementalArea.area53
+  content5:
+    Title: More paragraph content
+    Sort: 1
+    HTML: '<p>More paragraphs</p><p>And yet more</p>'
+    ParentID: =>DNADesign\Elemental\Models\ElementalArea.area53
 DNADesign\Elemental\Tests\Src\TestPage:
   elementaldemo:
     Title: Test Elemental
@@ -26,6 +38,9 @@ DNADesign\Elemental\Tests\Src\TestPage:
   page_with_one_element:
     Title: Page with one elements
     ElementalAreaID: =>DNADesign\Elemental\Models\ElementalArea.area52
+  page_with_html_elements:
+    Title: Page with html elements
+    ElementalAreaID: =>DNADesign\Elemental\Models\ElementalArea.area53
 SilverStripe\CMS\Model\RedirectorPage:
   elementredirectpage:
     Title: Redirector Page


### PR DESCRIPTION
Having an issue where this method combines `<p>` tags into a single string, muddying my search results, i.e.

```html
<p>banana</p>
<p>hamburger</p>
```

becomes `bananahamburger` when this method is called.

Starting with a failing test - going to propose a fix which should replace these with spaces