### PR TITLE
Add config to disable the content search in ElementSiteTreeFilterSearch

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,6 +292,19 @@ The Solr search results may add in emphasis tags or other formatting around matc
 to allow unescaped HTML in your search results template. You should use the `$Excerpt` property (see
 `SolrIndex::search` for more) to display the relevant search matches.
 
+### Disabling CMS content search
+
+When installing this module, the page model admin search will look for a term in the entire content of each elemental pages.
+This is done by rendering each page, which can be resource hungry and make the search timeout.
+
+You can disable this with YAML configuration:
+
+```yaml
+# File: mysite/_config/elements.yml
+DNADesign\Elemental\Controllers\ElementSiteTreeFilterSearch:
+  search_for_term_in_content: false
+```
+
 ### Usage of GridField
 
 This module used to use GridField to create and update Elements in the CMS. This has now been largely succeeded by a JavaScript interface via React. However elements that are marked as being incompatible with in-line editing will still use the GridField method.

--- a/src/Controllers/ElementSiteTreeFilterSearch.php
+++ b/src/Controllers/ElementSiteTreeFilterSearch.php
@@ -5,15 +5,21 @@ namespace DNADesign\Elemental\Controllers;
 use DNADesign\Elemental\Extensions\ElementalPageExtension;
 use SilverStripe\CMS\Controllers\CMSSiteTreeFilter_Search;
 use SilverStripe\CMS\Model\SiteTree;
-use SilverStripe\Core\Config\Config;
+use SilverStripe\Core\Config\Configurable;
 use SilverStripe\Core\Convert;
 use SilverStripe\Forms\DateField;
 use SilverStripe\ORM\ArrayList;
 use SilverStripe\ORM\DataList;
-use SilverStripe\View\SSViewer;
 
 class ElementSiteTreeFilterSearch extends CMSSiteTreeFilter_Search
 {
+    use Configurable;
+
+    /**
+     * @var boolean
+     */
+    private static $search_for_term_in_content = true;
+
     /**
      * @var array
      */
@@ -29,7 +35,7 @@ class ElementSiteTreeFilterSearch extends CMSSiteTreeFilter_Search
     protected function applyDefaultFilters($query)
     {
         // If not filtering by a Term then skip this altogether
-        if (empty($this->params['Term'])) {
+        if (empty($this->params['Term']) || $this->config()->get('search_for_term_in_content') === false) {
             return parent::applyDefaultFilters($query);
         }
 


### PR DESCRIPTION
We have found that with large website, with hundreds of elemental page, the CMS Page search no longer works as every page gets rendered, which is too time consuming.
This allows to disable the content search via a config.