### PR TITLE
NEW Get anchor links from elemental pages

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     },
     "require-dev": {
       "silverstripe/recipe-testing": "^2",
-      "silverstripe/frameworktest": "4.x-dev"
+      "silverstripe/frameworktest": "^0.4.5"
     },
     "suggest": {
         "silverstripe/elemental-blocks": "Adds a set of common SilverStripe content block types",

--- a/tests/BaseElementTest.php
+++ b/tests/BaseElementTest.php
@@ -12,6 +12,7 @@ use DNADesign\Elemental\Tests\Src\TestDataObject;
 use DNADesign\Elemental\Tests\Src\TestElement;
 use DNADesign\Elemental\Tests\Src\TestElementDataObject;
 use DNADesign\Elemental\Tests\Src\TestDataObjectWithCMSEditLink;
+use DNADesign\Elemental\Tests\Src\TestMultipleHtmlFieldsElement;
 use DNADesign\Elemental\Tests\Src\TestPage;
 use Page;
 use ReflectionClass;
@@ -46,6 +47,7 @@ class BaseElementTest extends FunctionalTest
         TestDataObject::class,
         TestDataObjectWithCMSEditLink::class,
         TestElementDataObject::class,
+        TestMultipleHtmlFieldsElement::class,
     ];
 
     public function testSimpleClassName()
@@ -269,6 +271,38 @@ class BaseElementTest extends FunctionalTest
         // Content should be updated by the extension
         $this->assertEquals('This is the updated content.', $element->getContentForSearchIndex());
         ElementContent::remove_extension(TestContentForSearchIndexExtension::class);
+    }
+
+    public function getElementAnchorDataProvider(): array
+    {
+        return [
+            [
+                TestMultipleHtmlFieldsElement::class,
+                'multiHtmlFields1',
+                [
+                    'anchor1',
+                    'anchor2',
+                    'anchor3',
+                    'anchor4',
+                ]
+            ],
+            [
+                TestMultipleHtmlFieldsElement::class,
+                'multiHtmlFields2',
+                []
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider getElementAnchorDataProvider
+     */
+    public function testGetAnchorsInContent(string $elementClass, string $elementName, array $expectedAnchors): void
+    {
+        $element = $this->objFromFixture($elementClass, $elementName);
+        array_unshift($expectedAnchors, $element->getAnchor());
+        // We use array values here because `array_unique` in `getAnchorsInContent()` doesn't reset array indices
+        $this->assertSame($expectedAnchors, array_values($element->getAnchorsInContent()));
     }
 
     public function getElementCMSLinkDataProvider()

--- a/tests/Behat/Context/FixtureContext.php
+++ b/tests/Behat/Context/FixtureContext.php
@@ -13,7 +13,7 @@ if (!class_exists(BaseFixtureContext::class)) {
 class FixtureContext extends BaseFixtureContext
 {
     /**
-     * @Given /(?:the|a) "([^"]+)" "([^"]+)" (?:with|has) a "([^"]+)" content element with "([^"]+)" content/
+     * @Given /(?:the|a) "([^"]+)" "([^"]+)" (?:with|has) a "([^"]+)" content element with "(.*)" content/
      *
      * @param string $pageTitle
      * @param string $type

--- a/tests/Behat/features/add-link-to-anchor.feature
+++ b/tests/Behat/features/add-link-to-anchor.feature
@@ -1,0 +1,62 @@
+Feature: Link to anchors in elements
+As a cms author
+I want to link to anchors in my content
+So that I can direct users directly to the relevant information
+
+  Background:
+    Given a "page" "No Blocks" has the "Content" "<p>My awesome content<a name="normal-anchor"></a></p>"
+      And a "BasicElementalPage" "Elemental" with a "Anchor Test Block" content element with "<p>My awesomer content<a name="element-anchor"></a></p>" content
+      And the "BasicElementalPage" "Elemental" has a "Same Page Anchor Block" content element with "<p><a id="another-anchor"></a></p>" content
+      And I am logged in with "ADMIN" permissions
+      And I go to "/admin/pages"
+
+  Scenario: I can link to anchors in an elemental block from a normal page
+    Given I left click on "No Blocks" in the tree
+      And I select "awesome" in the "Content" HTML field
+      And I press the "Insert link" HTML field button
+      And I click "Anchor on a page" in the ".mce-menu" element
+    Then I should see an "form#Form_editorAnchorLink" element
+      And I should see "No Blocks" in the "#Form_editorAnchorLink_PageID_Holder .Select-multi-value-wrapper" element
+    When I click "No Blocks" in the "#Form_editorAnchorLink_PageID_Holder .Select-multi-value-wrapper" element
+      And I click "Elemental" in the "#Form_editorAnchorLink_PageID_Holder .Select-menu-outer" element
+      And I click "Select or enter anchor" in the "#Form_editorAnchorLink_Anchor_Holder .Select-multi-value-wrapper" element
+      And I click "element-anchor" in the "#Form_editorAnchorLink_Anchor_Holder .Select-menu-outer" element
+    Then I should see "element-anchor" in the "#Form_editorAnchorLink_Anchor_Holder .Select-value" element
+    # Close the dialog now that we're done with it.
+    When I click on the "button.close" element
+
+  Scenario: I can link to anchors on a normal page from an elemental block
+    Given I left click on "Elemental" in the tree
+    Then I should see a list of blocks
+      And I should see "Anchor Test Block"
+    Given I click on block 1
+      Then the "Content" field for block 1 should contain "My awesomer content"
+    When I select "awesomer" in the "Content" HTML field
+      And I press the "Insert link" HTML field button
+      And I click "Anchor on a page" in the ".mce-menu" element
+    Then I should see an "form#Form_editorAnchorLink" element
+      And I should see "Elemental" in the "#Form_editorAnchorLink_PageID_Holder .Select-multi-value-wrapper" element
+    When I click "Elemental" in the "#Form_editorAnchorLink_PageID_Holder .Select-multi-value-wrapper" element
+      And I click "No Blocks" in the "#Form_editorAnchorLink_PageID_Holder .Select-menu-outer" element
+      And I click "Select or enter anchor" in the "#Form_editorAnchorLink_Anchor_Holder .Select-multi-value-wrapper" element
+      And I click "normal-anchor" in the "#Form_editorAnchorLink_Anchor_Holder .Select-menu-outer" element
+    Then I should see "normal-anchor" in the "#Form_editorAnchorLink_Anchor_Holder .Select-value" element
+    # Close the dialog now that we're done with it.
+    When I click on the "button.close" element
+
+  Scenario: I can link to anchors in an elemental block from another elemental block
+    Given I left click on "Elemental" in the tree
+      And I should see a list of blocks
+      And I should see "Anchor Test Block"
+    Given I click on block 1
+      Then the "Content" field for block 1 should contain "My awesomer content"
+    When I select "awesomer" in the "Content" HTML field
+      And I press the "Insert link" HTML field button
+      And I click "Anchor on a page" in the ".mce-menu" element
+    Then I should see an "form#Form_editorAnchorLink" element
+      And I should see "Elemental" in the "#Form_editorAnchorLink_PageID_Holder .Select-multi-value-wrapper" element
+    When I click "Select or enter anchor" in the "#Form_editorAnchorLink_Anchor_Holder .Select-multi-value-wrapper" element
+      And I click "another-anchor" in the "#Form_editorAnchorLink_Anchor_Holder .Select-menu-outer" element
+    Then I should see "another-anchor" in the "#Form_editorAnchorLink_Anchor_Holder .Select-value" element
+    # Close the dialog now that we're done with it.
+    When I click on the "button.close" element

--- a/tests/ElementalAreaDataObjectTest.yml
+++ b/tests/ElementalAreaDataObjectTest.yml
@@ -14,7 +14,7 @@ DNADesign\Elemental\Models\ElementalArea:
 
 DNADesign\Elemental\Tests\Src\TestDataObjectWithCMSEditLink:
   dataObject1:
-    Title: DataObject with CMSEditLink method 
+    Title: DataObject with CMSEditLink method
     ElementalAreaID: =>DNADesign\Elemental\Models\ElementalArea.areaDataObject1
 
 DNADesign\Elemental\Tests\Src\TestDataObject:
@@ -60,3 +60,12 @@ DNADesign\Elemental\Models\ElementContent:
   contentDataObject1:
     HTML: Some content
     ParentID: =>DNADesign\Elemental\Models\ElementalArea.areaDataObject1
+
+DNADesign\Elemental\Tests\Src\TestMultipleHtmlFieldsElement:
+  multiHtmlFields1:
+    Field1: '<p><a id="anchor1"></a><span name="anchor2"></span></p>'
+    Field2: '<p><a id="anchor1"></a><span name="anchor3"></span></p>'
+    Field3: '<p><a id="anchor4"></a><span name="anchor3"></span></p>'
+  multiHtmlFields2:
+    Field1: '<p>id="not-anchor"</p>'
+    Field2: '<p>name="not-anchor2"</p>'

--- a/tests/Src/TestMultiHtmlFieldsElement.php
+++ b/tests/Src/TestMultiHtmlFieldsElement.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace DNADesign\Elemental\Tests\Src;
+
+use DNADesign\Elemental\Models\BaseElement;
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\Security\Permission;
+
+class TestMultipleHtmlFieldsElement extends BaseElement implements TestOnly
+{
+    private static $table_name = 'TestMultipleHtmlFieldsElement';
+
+    private static $db = [
+        'Field1' => 'HTMLText',
+        'Field2' => 'HTMLText',
+        'Field3' => 'HTMLText',
+    ];
+}


### PR DESCRIPTION
Adds anchor links in `HTMLText` fields on an elemental block to the "anchor on a page" link form in WYSIWYG fields.
The new method should be overridden for blocks that need to add additional anchors or exclude some anchors from this base list.

An argument can be made that this should render the block and use that to parse out any anchors - but the approach this PR takes is more in line with how this is currently done in `SiteTree::getAnchorsOnPage()`.

Also updated the `theHasAContentElementWithContent` fixture context regex to allow arbitrary html content in the test fixture.

## Dependencies
The following related PRs must be merged in first in order for tests to pass
- https://github.com/silverstripe/silverstripe-frameworktest/pull/106
- https://github.com/silverstripe/silverstripe-cms/pull/2741

## Parent Issues
- https://github.com/silverstripe/silverstripe-elemental/issues/186