### PR TITLE
FIX: Display validation messages against the ElementalArea.

### DIFF
--- a/templates/DNADesign/Elemental/Forms/ElementalAreaField_holder.ss
+++ b/templates/DNADesign/Elemental/Forms/ElementalAreaField_holder.ss
@@ -1,3 +1,4 @@
 <div $AttributesHTML data-schema="$SchemaData.JSON">
     <%-- Field is rendered by React components --%>
 </div>
+<% if $Message %><span class="message $MessageType">$Message</span><% end_if %>


### PR DESCRIPTION
It is possible to create a validator that can add validation messages against the ElementalArea as a whole. Currently, the CMS will display the toast indicating there was an error, but the error message itself isn't displayed.
Render the validation error in the ElementalArea's field holder template.