### PR TITLE
Allow custom actions to be added

### DIFF
--- a/client/src/boot/registerComponents.js
+++ b/client/src/boot/registerComponents.js
@@ -22,6 +22,9 @@ export default () => {
     ElementList,
     Element,
     ElementActions,
+    // This has been left intentionally empty as it is a section that
+    // is designed to be added to/overridden by other modules
+    ElementCustomActions: () => () => null,
     ElementHeader: Header,
     ElementContent: Content,
     ElementSummary: Summary,

--- a/client/src/boot/registerComponents.js
+++ b/client/src/boot/registerComponents.js
@@ -1,6 +1,7 @@
 import Injector from 'lib/Injector';
 import Element from 'components/ElementEditor/Element';
 import ElementActions from 'components/ElementEditor/ElementActions';
+import CustomActions from 'components/ElementActions/CustomActions';
 import ElementEditor from 'components/ElementEditor/ElementEditor';
 import ElementList from 'components/ElementEditor/ElementList';
 import Toolbar from 'components/ElementEditor/Toolbar';
@@ -22,9 +23,7 @@ export default () => {
     ElementList,
     Element,
     ElementActions,
-    // This has been left intentionally empty as it is a section that
-    // is designed to be added to/overridden by other modules
-    ElementCustomActions: () => () => null,
+    ElementCustomActions: CustomActions,
     ElementHeader: Header,
     ElementContent: Content,
     ElementSummary: Summary,

--- a/client/src/components/ElementActions/CustomActions.js
+++ b/client/src/components/ElementActions/CustomActions.js
@@ -1,0 +1,18 @@
+import React from "react";
+
+const CustomActions = (props) => {
+  const { children } = props;
+
+  // Don't render if there are no children
+  if (!Array.isArray(children) || !children.length > 0) {
+    return null;
+  }
+
+  return (
+    <div role="none" onClick={(event) => event.stopPropagation()}>
+      {children}
+    </div>
+  );
+};
+
+export default CustomActions;

--- a/client/src/components/ElementEditor/Header.js
+++ b/client/src/components/ElementEditor/Header.js
@@ -112,6 +112,7 @@ class Header extends Component {
       activeTab,
       expandable,
       ElementActionsComponent,
+      ElementCustomActionsComponent,
       handleEditTabsClick,
     } = this.props;
 
@@ -160,6 +161,11 @@ class Header extends Component {
           <h3 className={titleClasses}>{element.title || noTitle}</h3>
         </div>
         {!simple && <div className="element-editor-header__actions">
+          {ElementCustomActionsComponent ? (
+            <div role="none" onClick={(event) => event.stopPropagation()}>
+              <ElementCustomActionsComponent {...this.props} />
+            </div>
+          ) : null}
           {expandable &&
             <div
               role="none"
@@ -224,9 +230,10 @@ export default compose(
   })),
   connect(mapStateToProps),
   inject(
-    ['ElementActions'],
-    (ElementActionsComponent) => ({
+    ['ElementActions', 'ElementCustomActions'],
+    (ElementActionsComponent, ElementCustomActionsComponent) => ({
       ElementActionsComponent,
+      ElementCustomActionsComponent,
     }),
     () => 'ElementEditor.ElementList.Element'
   )

--- a/client/src/components/ElementEditor/Header.js
+++ b/client/src/components/ElementEditor/Header.js
@@ -161,11 +161,7 @@ class Header extends Component {
           <h3 className={titleClasses}>{element.title || noTitle}</h3>
         </div>
         {!simple && <div className="element-editor-header__actions">
-          {ElementCustomActionsComponent ? (
-            <div role="none" onClick={(event) => event.stopPropagation()}>
-              <ElementCustomActionsComponent {...this.props} />
-            </div>
-          ) : null}
+          <ElementCustomActionsComponent {...this.props} />
           {expandable &&
             <div
               role="none"


### PR DESCRIPTION
The idea here is that you can then in modules simply update this section to add custom actions like so:

```js
import Injector from "lib/Injector";

const WorkflowAction = (CustomActionsComponent) => (props) => {
  const { children } = props;

  return (
    <CustomActionsComponent>
      {children}
      <button>Example</button>
    </CustomActionsComponent>
  );
};

export default () => {
  Injector.transform("workflow", (updater) => {
    updater.component(
      "ElementCustomActions",
      WorkflowAction,
      "WorkflowElementalActions"
    );
  });
};
```

By default if there are no custom actions then it will return null so that it doesn't add anything to the DOM