### PR TITLE
FIX: Get CMS preview working for non inline-editable elements.

### DIFF
--- a/src/Models/BaseElement.php
+++ b/src/Models/BaseElement.php
@@ -31,6 +31,7 @@ use SilverStripe\VersionedAdmin\Forms\HistoryViewerField;
 use SilverStripe\View\ArrayData;
 use SilverStripe\View\Parsers\URLSegmentFilter;
 use SilverStripe\View\Requirements;
+use SilverStripe\ORM\CMSPreviewable;
 
 /**
  * Class BaseElement
@@ -47,7 +48,7 @@ use SilverStripe\View\Requirements;
  *
  * @mixin Versioned
  */
-class BaseElement extends DataObject
+class BaseElement extends DataObject implements CMSPreviewable
 {
     /**
      * Override this on your custom elements to specify a CSS icon class
@@ -112,6 +113,10 @@ class BaseElement extends DataObject
      * @var ElementController
      */
     protected $controller;
+
+    private static $show_stage_link = true;
+
+    private static $show_live_link = true;
 
     /**
      * Cache various data to improve CMS load time


### PR DESCRIPTION
Fixes #905. Depends on silverstripe/silverstripe-admin#1250

This was a feature in an earlier version of the module and most of the code is still in place.

Edit: While this technically depends on the PR from silverstripe-admin, it won't cause any defects if it does get merged in early, and merging it in even without that PR would make it easier for project-specific code to enable previews for elementals.