### PR TITLE
ENH Add extension points to update element controller styles and template

### DIFF
--- a/src/Controllers/ElementController.php
+++ b/src/Controllers/ElementController.php
@@ -73,17 +73,20 @@ class ElementController extends Controller
     public function forTemplate()
     {
         $defaultStyles = $this->config()->get('default_styles');
+        $this->extend('updateElementControllerDefaultStyles', $defaultStyles);
+
         if ($this->config()->get('include_default_styles') && !empty($defaultStyles)) {
             foreach ($defaultStyles as $stylePath) {
                 Requirements::css($stylePath);
             }
         }
 
-        $template = $this->element->config()->get('controller_template');
+        $template = 'DNADesign\\Elemental\\'.$this->element->config()->get('controller_template');
+        $this->extend('updateElementControllerTemplate', $template);
 
         return $this->renderWith([
             'type' => 'Layout',
-            'DNADesign\\Elemental\\'.$template
+            $template
         ]);
     }
 


### PR DESCRIPTION
For some use cases where a block requires a different holder template based on some other business logic requirements where the config system isn't sufficiently flexible during runtime, allow to update the styles and the controller/holder template via an extension to the element controller.