### PR TITLE
FIX: Version number hidden on HistoryViewerField

### DIFF
--- a/src/Models/BaseElement.php
+++ b/src/Models/BaseElement.php
@@ -360,7 +360,8 @@ class BaseElement extends DataObject
 
             if ($this->isInDB()) {
                 $fields->addFieldsToTab('Root.History', [
-                    HistoryViewerField::create('ElementHistory'),
+                    HistoryViewerField::create('ElementHistory')
+                        ->addExtraClass('history-viewer--standalone'),
                 ]);
                 // Add class to containing tab
                 $fields->fieldByName('Root.History')


### PR DESCRIPTION
This fixes a display issue for the element history list caused by legacy Entwine code which ends up setting isInGridField to true

https://github.com/silverstripe/silverstripe-versioned-admin/blob/1/client/src/legacy/HistoryViewer/HistoryViewerEntwine.js

See the following issue for more details

silverstripe/silverstripe-versioned-admin#188