### PR TITLE
Cosmetic change to italian translation

### DIFF
--- a/lang/it.yml
+++ b/lang/it.yml
@@ -29,7 +29,7 @@ it:
     PLURALNAME: 'Aree Elementi'
     PLURALS:
       one: 'Un''Area Elementi'
-      other: '{count} Aree Elementali'
+      other: '{count} Aree Elementi'
     SINGULARNAME: 'Area Elementi'
   DNADesign\Elemental\Reports\ElementTypeReport:
     Title: 'Tipi di blocchi dei contenuti'


### PR DESCRIPTION
Elemental Area can be translated to "Area Elementare" (lit. "Elemental Area") or Area Elemento (lit. "Element Area", preferred). As the latter has been chosen in the past, a plural form has been matched consequently.