### PR TITLE
FIX Use correct return type for permission checks

### DIFF
--- a/src/Models/BaseElement.php
+++ b/src/Models/BaseElement.php
@@ -203,7 +203,7 @@ class BaseElement extends DataObject
             }
         }
 
-        return (Permission::check('CMS_ACCESS', 'any', $member)) ? true : null;
+        return (Permission::check('CMS_ACCESS', 'any', $member)) ? true : false;
     }
 
     /**
@@ -226,7 +226,7 @@ class BaseElement extends DataObject
             }
         }
 
-        return (Permission::check('CMS_ACCESS', 'any', $member)) ? true : null;
+        return (Permission::check('CMS_ACCESS', 'any', $member)) ? true : false;
     }
 
     /**
@@ -253,7 +253,7 @@ class BaseElement extends DataObject
             }
         }
 
-        return (Permission::check('CMS_ACCESS', 'any', $member)) ? true : null;
+        return (Permission::check('CMS_ACCESS', 'any', $member)) ? true : false;
     }
 
     /**
@@ -271,7 +271,7 @@ class BaseElement extends DataObject
             return $extended;
         }
 
-        return (Permission::check('CMS_ACCESS', 'any', $member)) ? true : null;
+        return (Permission::check('CMS_ACCESS', 'any', $member)) ? true : false;
     }
 
     /**


### PR DESCRIPTION
The PHPDoc specifies that a boolean will be returned.

Returning a null causes a problem using SearchableService which, in `SearchableService::isSearchable`, can return the value from `canView` directly, expecting it to be a `boolean` (which then raises a `TypeError`).