### PR TITLE
FIX Match search terms at the start of a string

### DIFF
--- a/src/Controllers/ElementSiteTreeFilterSearch.php
+++ b/src/Controllers/ElementSiteTreeFilterSearch.php
@@ -49,7 +49,7 @@ class ElementSiteTreeFilterSearch extends CMSSiteTreeFilter_Search
 
             // Check whether the search term exists in the nested page content
             $pageContent = $siteTree->getElementsForSearch();
-            return (bool) stripos($pageContent, $this->params['Term']) !== false;
+            return stripos($pageContent, $this->params['Term']) !== false;
         });
 
         if ($siteTrees->count()) {


### PR DESCRIPTION
Needless bool cast causes search terms with a 0 index to not get matched

Caused [this failure](https://app.travis-ci.com/github/silverstripe/silverstripe-elemental/jobs/557992814)

On [this PR](https://github.com/silverstripe/silverstripe-elemental/pull/913) <- that PR is effectively the unit tests coverage for this PR

Because `getElementsForSearch()` now returns 'trimmed' content rather than content suuronded by whitespace which happened previously because the entire ElementalArea was being rendered, rather than individual content blocks delimited by a space 

**ElementalArea.ss** (includes whitespace before and after the elemental content)
```
<% if $ElementControllers %>
    <% loop $ElementControllers %>
	   $Me
    <% end_loop %>
<% end_if %>
```
