### PR TITLE
Add extension point onAfterElementalAreaCreation

### DIFF
--- a/src/Extensions/ElementalAreasExtension.php
+++ b/src/Extensions/ElementalAreasExtension.php
@@ -285,6 +285,8 @@ class ElementalAreasExtension extends DataExtension
                 $area->OwnerClassName = get_class($this->owner);
                 $area->write();
                 $this->owner->$areaID = $area->ID;
+
+                $this->owner->extend('onAfterElementalAreaCreation', $area, $eaRelationship);
             }
         }
         return $this->owner;


### PR DESCRIPTION
Add an extension point for after the Elemental Area has been created. The extension point can be used to do things such as add blocks to the Elemental Area by default when a page is created. It differs from the exisiting extension point `onAfterRequireDefaultElementalRecords` in that this new one is run every time the elemental area is created (e.g. when a new page is created) rather than when requireDefaultRecords is run during a dev/build.