### PR TITLE
FIX getOwnerPage() should respect Versioned state.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 /node_modules/
 /**/*.js.map
 /**/*.css.map
+/vendor/
+/resources/
+/assets/

--- a/src/Models/ElementalArea.php
+++ b/src/Models/ElementalArea.php
@@ -112,7 +112,9 @@ class ElementalArea extends DataObject
      */
     public function setOwnerPageCached(DataObject $page)
     {
-        $this->cacheData['owner_page'] = $page;
+        $cacheKey = 'owner_page_'. Versioned::get_reading_mode();
+
+        $this->cacheData[$cacheKey] = $page;
 
         return $this;
     }
@@ -193,8 +195,10 @@ class ElementalArea extends DataObject
         }
 
         // Allow for repeated calls to read from cache
-        if (isset($this->cacheData['owner_page'])) {
-            return $this->cacheData['owner_page'];
+        $cacheKey = 'owner_page_'. Versioned::get_reading_mode();
+
+        if (isset($this->cacheData[$cacheKey])) {
+            return $this->cacheData[$cacheKey];
         }
 
         if ($this->OwnerClassName && ClassInfo::exists($this->OwnerClassName)) {
@@ -217,6 +221,7 @@ class ElementalArea extends DataObject
 
                 if ($page) {
                     $this->setOwnerPageCached($page);
+
                     return $page;
                 }
             }
@@ -234,7 +239,7 @@ class ElementalArea extends DataObject
             }
 
             try {
-                $page = Versioned::get_by_stage($class, Versioned::DRAFT)->filterAny($areaIDFilters)->first();
+                $page = DataObject::get($class)->filterAny($areaIDFilters)->first();
             } catch (\Exception $ex) {
                 // Usually this is catching cases where test stubs from other modules are trying to be loaded
                 // and failing in unit tests.
@@ -255,7 +260,8 @@ class ElementalArea extends DataObject
                     }
                 }
 
-                $this->cacheData['area_relation_name'] = $page;
+                $this->setOwnerPageCached($page);
+
                 return $page;
             }
         }

--- a/tests/ElementalAreaTest.php
+++ b/tests/ElementalAreaTest.php
@@ -74,11 +74,29 @@ class ElementalAreaTest extends SapphireTest
 
         // OwnerClassName not set
         $ownerpage1 = $area1->getOwnerPage();
+
         // OwnerClassName set
         $ownerpage2 = $area2->getOwnerPage();
 
         $this->assertEquals("DNADesign\Elemental\Tests\Src\TestPage", $ownerpage1);
         $this->assertEquals("DNADesign\Elemental\Tests\Src\TestPage", $ownerpage2);
+
+        // if ownerpage1 has draft changes then getOwnerPage() should return the
+        // live version of the owner page, since the draft record will be
+        // unviewable by logged out users
+        $ownerpage1->publishRecursive();
+
+        $ownerpage1->Title = 'I have edited the page';
+        $ownerpage1->writeToStage(Versioned::DRAFT);
+
+        $liveOwner = Versioned::withVersionedMode(function () use ($area1) {
+            Versioned::set_stage(Versioned::LIVE);
+            $page = $area1->getOwnerPage();
+
+            return $page;
+        });
+
+        $this->assertEquals($liveOwner->Title, 'Page 1', 'getOwnerPage returns live version of page, not the draft');
     }
 
     public function testForTemplate()


### PR DESCRIPTION
Previous to this getOwnerPage() would always return the Draft versioned
record. This would lead to cases were if a parent page contained draft
changes, unauthenicated users would be blocked from viewing content
blocks as `$this->getOwnerPage()->canView($member);` would fail since
logged out users could not view pages with draft changes.