### PR TITLE
FIX Use PreviewLink of the owner object to preview blocks

### DIFF
--- a/src/Models/BaseElement.php
+++ b/src/Models/BaseElement.php
@@ -701,7 +701,7 @@ JS
 
     /**
      * @param string|null $action
-     * @return string
+     * @return string|null
      * @throws \Psr\Container\NotFoundExceptionInterface
      * @throws \SilverStripe\ORM\ValidationException
      */
@@ -721,16 +721,28 @@ JS
 
     /**
      * @param string|null $action
-     * @return string
+     * @return string|null
      * @throws \Psr\Container\NotFoundExceptionInterface
      * @throws \SilverStripe\ORM\ValidationException
      */
     public function PreviewLink($action = null)
     {
-        $action = $action . '?ElementalPreview=' . mt_rand();
-        $link = $this->Link($action);
-        $this->extend('updatePreviewLink', $link);
+        $link = null;
+        if ($page = $this->getPage()) {
+            if (ClassInfo::hasMethod($page, 'Link')) {
+                $link = $page->Link($action);
+            }
+            if (!$link && ($page instanceof CMSPreviewable)) {
+                $link = $page->PreviewLink($action);
+            }
+            if ($link) {
+                // The ElementalPreview getvar is used in ElementalPageExtension
+                // The anchor must be at the end of the URL to function correctly
+                $link .= '?ElementalPreview=' . mt_rand() . '#' . $this->getAnchor();
+            }
+        }
 
+        $this->extend('updatePreviewLink', $link);
         return $link;
     }
 

--- a/tests/BaseElementTest.php
+++ b/tests/BaseElementTest.php
@@ -401,4 +401,50 @@ class BaseElementTest extends FunctionalTest
         $absoluteLink = $object->AbsoluteLink();
         $this->assertEquals($link, $absoluteLink);
     }
+
+    public function previewLinksProvider()
+    {
+        return [
+            // Element on Page
+            [
+                ElementContent::class,
+                'content1',
+                '/test-elemental/',
+            ],
+            // Element in DataObject WITHOUT PreviewLink or Link
+            [
+                TestElement::class,
+                'elementDataObject2',
+                null,
+            ],
+            // Element in DataObject WITH PreviewLink WITHOUT Link
+            [
+                TestElement::class,
+                'elementDataObject3',
+                'preview-link',
+            ],
+            // Element in DataObject WITH PreviewLink AND Link (different paths)
+            [
+                TestElement::class,
+                'elementDataObject4',
+                'base-link',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider previewLinksProvider
+     */
+    public function testPreviewLink(string $class, string $elementIdentifier, ?string $link)
+    {
+        /** @var BaseElement $element */
+        $element = $this->objFromFixture($class, $elementIdentifier);
+
+        if ($link) {
+            $regex = '/^' . preg_quote($link . '?ElementalPreview=', '/') .'\d*#' . $element->getAnchor() . '$/';
+            $this->assertTrue((bool)preg_match($regex, $element->PreviewLink()));
+        } else {
+            $this->assertSame($link, $element->PreviewLink());
+        }
+    }
 }

--- a/tests/ElementalAreaDataObjectTest.yml
+++ b/tests/ElementalAreaDataObjectTest.yml
@@ -5,6 +5,12 @@ DNADesign\Elemental\Models\ElementalArea:
   areaDataObject2:
     Title: Area 2
     OwnerClassName: DNADesign\Elemental\Tests\Src\TestDataObject
+  areaDataObject3:
+    Title: Area 3
+    OwnerClassName: DNADesign\Elemental\Tests\Src\TestPreviewableDataObject
+  areaDataObject4:
+    Title: Area 4
+    OwnerClassName: DNADesign\Elemental\Tests\Src\TestPreviewableDataObjectWithLink
 
 DNADesign\Elemental\Tests\Src\TestDataObjectWithCMSEditLink:
   dataObject1:
@@ -13,8 +19,18 @@ DNADesign\Elemental\Tests\Src\TestDataObjectWithCMSEditLink:
 
 DNADesign\Elemental\Tests\Src\TestDataObject:
   dataObject2:
-    Title: DataObject without CMSEditLink method
+    Title: DataObject without CMSEditLink, Link, or PreviewLink methods
     ElementalAreaID: =>DNADesign\Elemental\Models\ElementalArea.areaDataObject2
+
+DNADesign\Elemental\Tests\Src\TestPreviewableDataObject:
+  dataObject3:
+    Title: DataObject with PreviewLink method
+    ElementalAreaID: =>DNADesign\Elemental\Models\ElementalArea.areaDataObject3
+
+DNADesign\Elemental\Tests\Src\TestPreviewableDataObjectWithLink:
+  dataObject4:
+    Title: DataObject with PreviewLink and Link methods
+    ElementalAreaID: =>DNADesign\Elemental\Models\ElementalArea.areaDataObject4
 
 DNADesign\Elemental\Tests\Src\TestElement:
   elementDataObject1:
@@ -25,6 +41,14 @@ DNADesign\Elemental\Tests\Src\TestElement:
     Title: Element 2
     TestValue: 'Hello Test'
     ParentID: =>DNADesign\Elemental\Models\ElementalArea.areaDataObject2
+  elementDataObject3:
+    Title: Element 3
+    TestValue: 'Hello Test'
+    ParentID: =>DNADesign\Elemental\Models\ElementalArea.areaDataObject3
+  elementDataObject4:
+    Title: Element 4
+    TestValue: 'Hello Test'
+    ParentID: =>DNADesign\Elemental\Models\ElementalArea.areaDataObject4
 
 DNADesign\Elemental\Tests\Src\TestElementDataObject:
   testElementDataObject1:

--- a/tests/Src/TestDataObject.php
+++ b/tests/Src/TestDataObject.php
@@ -3,8 +3,6 @@
 namespace DNADesign\Elemental\Tests\Src;
 
 use DNADesign\Elemental\Models\ElementalArea;
-use SilverStripe\Control\Controller;
-use SilverStripe\Control\Director;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\Dev\TestOnly;
 

--- a/tests/Src/TestPreviewableDataObject.php
+++ b/tests/Src/TestPreviewableDataObject.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace DNADesign\Elemental\Tests\Src;
+
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\ORM\CMSPreviewable;
+
+class TestPreviewableDataObject extends TestDataObject implements TestOnly, CMSPreviewable
+{
+    private static $table_name = 'TestPreviewableDataObject';
+
+    public function PreviewLink($action = null)
+    {
+        return 'preview-link';
+    }
+
+    public function getMimeType()
+    {
+        return null;
+    }
+
+    public function CMSEditLink()
+    {
+        return null;
+    }
+}

--- a/tests/Src/TestPreviewableDataObjectWithLink.php
+++ b/tests/Src/TestPreviewableDataObjectWithLink.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace DNADesign\Elemental\Tests\Src;
+
+use SilverStripe\Dev\TestOnly;
+
+class TestPreviewableDataObjectWithLink extends TestPreviewableDataObject implements TestOnly
+{
+    private static $table_name = 'TestPreviewableDataObjectWithLink';
+
+    public function Link($action = null)
+    {
+        return 'base-link';
+    }
+}


### PR DESCRIPTION
#871 allows `ElementalArea` to be added to any arbitrary `DataObject`. We should always try to set the correct preview link where possible. Some `DataObject`s may have a `PreviewLink` method for preview in the CMS, but no front-end link.

Finally, we should fallback to returning a null value if no link could be obtained for preview, so that the preview panel can correctly display a "no preview available" message.

## Parent Issues
- #871 

## Related
- silverstripe/silverstripe-admin#1304