### PR TITLE
MNT Fix tests after upgrading webonyx/graphql-php

### DIFF
--- a/tests/GraphQL/Legacy/AddElementToAreaMutationTest.php
+++ b/tests/GraphQL/Legacy/AddElementToAreaMutationTest.php
@@ -5,7 +5,7 @@ namespace DNADesign\Elemental\Tests\Legacy\GraphQL;
 use DNADesign\Elemental\GraphQL\AddElementToAreaMutation;
 use DNADesign\Elemental\Models\ElementalArea;
 use DNADesign\Elemental\Tests\Src\TestElement;
-use GraphQL\Type\Definition\ResolveInfo;
+use SilverStripe\GraphQL\Tests\Fake\FakeResolveInfo;
 use InvalidArgumentException;
 use SilverStripe\Dev\SapphireTest;
 use SilverStripe\GraphQL\Schema\Schema;
@@ -81,7 +81,7 @@ class AddElementToAreaMutationTest extends SapphireTest
     {
         $mutation = new AddElementToAreaMutation();
         $context = ['currentUser' => Security::getCurrentUser()];
-        $resolveInfo = new ResolveInfo([]);
+        $resolveInfo = new FakeResolveInfo([]);
 
         $args = [
             'className' => $className,

--- a/tests/GraphQL/Legacy/SortBlockMutationCreatorTest.php
+++ b/tests/GraphQL/Legacy/SortBlockMutationCreatorTest.php
@@ -4,7 +4,7 @@ namespace DNADesign\Elemental\Tests\Legacy\GraphQL;
 
 use DNADesign\Elemental\GraphQL\SortBlockMutationCreator;
 use DNADesign\Elemental\Tests\Src\TestElement;
-use GraphQL\Type\Definition\ResolveInfo;
+use SilverStripe\GraphQL\Tests\Fake\FakeResolveInfo;
 use SilverStripe\Dev\SapphireTest;
 use SilverStripe\GraphQL\Schema\Schema;
 use SilverStripe\Security\Security;
@@ -56,7 +56,7 @@ class SortBlockMutationCreatorTest extends SapphireTest
 
         $mutation = new SortBlockMutationCreator();
         $context = ['currentUser' => $member];
-        $resolveInfo = new ResolveInfo([]);
+        $resolveInfo = new FakeResolveInfo([]);
 
         $mutation->resolve(null, [
             'id' => $id,


### PR DESCRIPTION
The tests on the 4.8 branch [are failing](https://app.travis-ci.com/github/silverstripe/silverstripe-elemental/builds/250482412) after upgrading webonyx/graphql-php in graphql v3 (see silverstripe/silverstripe-graphql#454). This PR resolves that.

Note that the php 8.1 test will still have errors - this is expected, since this branch uses silverstripe 4.10