### PR TITLE
MNT Use php7.3 syntax on TestOnly object

### DIFF
--- a/tests/Src/TestDataObject.php
+++ b/tests/Src/TestDataObject.php
@@ -12,7 +12,7 @@ class TestDataObject extends DataObject implements TestOnly
 {
     private static $table_name = 'TestDataObject';
 
-    private static array $db = [
+    private static $db = [
         'Title' => 'Varchar(255)',
         'Content' => 'HTMLText',
     ];

--- a/tests/Src/TestDataObjectWithCMSEditLink.php
+++ b/tests/Src/TestDataObjectWithCMSEditLink.php
@@ -14,7 +14,7 @@ class TestDataObjectWithCMSEditLink extends DataObject implements TestOnly
 {
     private static $table_name = 'TestDataObjectWithCMSEditLink';
 
-    private static array $db = [
+    private static $db = [
         'Title' => 'Varchar(255)',
         'Content' => 'HTMLText',
     ];

--- a/tests/Src/TestElementDataObject.php
+++ b/tests/Src/TestElementDataObject.php
@@ -13,7 +13,7 @@ class TestElementDataObject extends BaseElement implements TestOnly
         'TestValue' => 'Text',
     ];
 
-    private static bool $inline_editable = false;
+    private static $inline_editable = false;
 
     public function getType()
     {


### PR DESCRIPTION
Issue https://github.com/silverstripe/gha-ci/issues/37

Blocked by https://github.com/silverstripe/silverstripe-graphql/pull/489

Fix php73 job https://github.com/silverstripe/recipe-content-blocks/runs/7457942097?check_suite_focus=true
`1) DNADesign\Elemental\Tests\BaseElementTest::testSimpleClassName
ParseError: syntax error, unexpected 'array' (T_ARRAY), expecting function (T_FUNCTION) or const (T_CONST) in /home/runner/work/recipe-content-blocks/recipe-content-blocks/vendor/dnadesign/silverstripe-elemental/tests/Src/TestDataObject.php:15`

TestOnly class so we can freely change