### PR TITLE
FIX Use consistent name for BaseElement graphql typename

### DIFF
--- a/src/Models/BaseElement.php
+++ b/src/Models/BaseElement.php
@@ -1159,8 +1159,10 @@ JS
      */
     public static function getGraphQLTypeName(): string
     {
-        return class_exists(StaticSchema::class)
-            ? StaticSchema::inst()->typeNameForDataObject(static::class)
-            : str_replace('\\', '_', static::class);
+        // For GraphQL 3, use the static schema type name - except for BaseElement for which this is inconsistent.
+        if (class_exists(StaticSchema::class) && static::class !== self::class) {
+            return StaticSchema::inst()->typeNameForDataObject(static::class);
+        }
+        return str_replace('\\', '_', static::class);
     }
 }


### PR DESCRIPTION
Fixes a problem where with GraphQL 3 the type name for base element in the block schema is inconsistent, causing broken blocks to not display as broken blocks.

Found in a behat test. See https://github.com/silverstripe/silverstripe-elemental/runs/7683686485?check_suite_focus=true#step:12:305
> The text "This element is of obsolete type BrokenClass." was not found anywhere in the text of the current page. (Behat\Mink\Exception\ResponseTextException)

Note that this _only_ affects broken blocks, as everything else uses an appropriate generated type name.

## Parent issue
- https://github.com/silverstripeltd/product-issues/issues/580